### PR TITLE
Make all user defined options can be taken by highcharts-ng

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -134,22 +134,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
         }
       });
 
-      if(config.title) {
-        mergedOptions.title = config.title;
-      }
-      if (config.subtitle) {
-        mergedOptions.subtitle = config.subtitle;
-      }
-      if (config.credits) {
-        mergedOptions.credits = config.credits;
-      }
-      if(config.size) {
-        if (config.size.width) {
-          mergedOptions.chart.width = config.size.width;
-        }
-        if (config.size.height) {
-          mergedOptions.chart.height = config.size.height;
-        }
+      for (var propertyName in config) {
+          mergedOptions[propertyName] = config[propertyName];
       }
       return mergedOptions;
     };


### PR DESCRIPTION
There are many Highcharts API cannot be supported by highcharts-ng. The main reason is the merged options only takes some config from user defined object (ex: title, subtitle, credits... etc). I think highcharts-ng should take all the user config then used the default options if user doesn't define it.